### PR TITLE
add tracing output in OpenMP parallel region

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2292,3 +2292,8 @@
 
 # /VEX/switchback/
 /VEX/switchback/switchback
+
+# Tracing output
+*.addr
+*.out
+*-t*-mrc.txt

--- a/cachegrind/cg_main.c
+++ b/cachegrind/cg_main.c
@@ -61,6 +61,7 @@
 static Bool  clo_cache_sim  = True;  /* do cache simulation? */
 static Bool  clo_branch_sim = False; /* do branch simulation? */
 static const HChar* clo_cachegrind_out_file = "cachegrind.out.%p";
+static const HChar* target_func = ".omp_outlined.";
 
 /*------------------------------------------------------------*/
 /*--- Cachesim configuration                               ---*/
@@ -391,9 +392,9 @@ void log_1IrNoX_1Dr_cache_access(InstrInfo* n, Addr data_addr, Word data_size)
    cachesim_I1_doref_NoX(n->instr_addr, n->instr_len,
 			 &n->parent->Ir.m1, &n->parent->Ir.mL);
    n->parent->Ir.a++;
-
+   int isInROI = (VG_(strstr)(get_perm_string(n->parent->loc.fn), target_func) != NULL);
    cachesim_D1_doref(data_addr, data_size, 
-                     &n->parent->Dr.m1, &n->parent->Dr.mL);
+                     &n->parent->Dr.m1, &n->parent->Dr.mL, isInROI);
    n->parent->Dr.a++;
 }
 
@@ -406,9 +407,9 @@ void log_1IrNoX_1Dw_cache_access(InstrInfo* n, Addr data_addr, Word data_size)
    cachesim_I1_doref_NoX(n->instr_addr, n->instr_len,
 			 &n->parent->Ir.m1, &n->parent->Ir.mL);
    n->parent->Ir.a++;
-
+   int isInROI = (VG_(strstr)(get_perm_string(n->parent->loc.fn), target_func) != NULL);
    cachesim_D1_doref(data_addr, data_size, 
-                     &n->parent->Dw.m1, &n->parent->Dw.mL);
+                     &n->parent->Dw.m1, &n->parent->Dw.mL, isInROI);
    n->parent->Dw.a++;
 }
 
@@ -420,8 +421,9 @@ void log_0Ir_1Dr_cache_access(InstrInfo* n, Addr data_addr, Word data_size)
 {
    //VG_(printf)("0Ir_1Dr:  CCaddr=0x%010lx,  daddr=0x%010lx,  dsize=%lu\n",
    //            n, data_addr, data_size);
+   int isInROI = (VG_(strstr)(get_perm_string(n->parent->loc.fn), target_func) != NULL);
    cachesim_D1_doref(data_addr, data_size, 
-                     &n->parent->Dr.m1, &n->parent->Dr.mL);
+                     &n->parent->Dr.m1, &n->parent->Dr.mL, isInROI);
    n->parent->Dr.a++;
 }
 
@@ -431,8 +433,9 @@ void log_0Ir_1Dw_cache_access(InstrInfo* n, Addr data_addr, Word data_size)
 {
    //VG_(printf)("0Ir_1Dw:  CCaddr=0x%010lx,  daddr=0x%010lx,  dsize=%lu\n",
    //            n, data_addr, data_size);
+   int isInROI = (VG_(strstr)(get_perm_string(n->parent->loc.fn), target_func) != NULL);
    cachesim_D1_doref(data_addr, data_size, 
-                     &n->parent->Dw.m1, &n->parent->Dw.mL);
+                     &n->parent->Dw.m1, &n->parent->Dw.mL, isInROI);
    n->parent->Dw.a++;
 }
 

--- a/cachegrind/cg_sim.c
+++ b/cachegrind/cg_sim.c
@@ -205,17 +205,24 @@ void cachesim_I1_doref_NoX(Addr a, UChar size, ULong* m1, ULong *mL)
 
 __attribute__((always_inline))
 static __inline__
-void cachesim_D1_doref(Addr a, UChar size, ULong* m1, ULong *mL)
+void cachesim_D1_doref(Addr a, UChar size, ULong* m1, ULong *mL, int inROI)
 {
    for (tuple_node_t * node = tuples; node != NULL; node = node->next) {
-       if (a >= node->base && a < node->base + size) {
-           (*m1)++;
-           if (cachesim_ref_is_miss(&LL, a, size))
-               (*mL)++;
-           break;
-       }
+      if (inROI) {
+         if (a >= node->base && a < node->base + node->size) {
+            UWord block1 =  a         >> (&LL)->line_size_bits;
+            UWord block2 = (a+size-1) >> (&LL)->line_size_bits;
+            UInt  set1   = block1 & (&LL)->sets_min_1;
+            VG_(printf)("s%u,%lx,%lx\n",set1,a,block1);
+            (*m1)++;
+            if (cachesim_ref_is_miss(&LL, a, size))
+                  (*mL)++;
+            break;
+         }
+      } else {
+         break;
+      }
    }
-
 }
 
 /* Check for special case IrNoX. Called at instrumentation time.


### PR DESCRIPTION
Dump the address trace in the OpenMP parallel region. 
Fix the bug in the address checker: Use the size inside the tuple node, not the size in the function argument